### PR TITLE
DM-37943: Add starCatalog output

### DIFF
--- a/python/lsst/drp/tasks/gbdesAstrometricFit.py
+++ b/python/lsst/drp/tasks/gbdesAstrometricFit.py
@@ -26,7 +26,6 @@ import astropy.coordinates
 import yaml
 import wcsfit
 import astshim
-import pyarrow as pa
 
 import lsst.geom
 import lsst.pex.config as pexConfig
@@ -263,6 +262,12 @@ class GbdesAstrometricFitConnections(pipeBase.PipelineTaskConnections,
         name='gbdesAstrometricFit_fitStars',
         storageClass='ArrowTable',
         dimensions=('instrument', 'skymap', 'tract', 'physical_filter'),
+    )
+    starCatalog = pipeBase.connectionTypes.Output(
+        doc="",
+        name='gbdesAstrometricFit_starCatalog',
+        storageClass='ArrowTable',
+        dimensions=('instrument', 'skymap', 'tract', 'physical_filter')
     )
 
 
@@ -534,10 +539,13 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
 
         outputWCSs = self._make_outputs(wcsf, inputVisitSummaries, exposureInfo)
         outputCatalog = pa.Table.from_pydict(wcsf.getOutputCatalog())
+        import ipdb; ipdb.set_trace()
+        starCatalog = parquet.numpy_dict_to_arrow(wcsf.getStarCatalog())
 
         return pipeBase.Struct(outputWCSs=outputWCSs,
                                fitModel=wcsf,
-                               outputCatalog=outputCatalog)
+                               outputCatalog=outputCatalog,
+                               starCatalog=starCatalog)
 
     def _prep_sky(self, inputVisitSummaries, epoch, fieldName='Field'):
         """Get center and radius of the input tract. This assumes that all

--- a/python/lsst/drp/tasks/gbdesAstrometricFit.py
+++ b/python/lsst/drp/tasks/gbdesAstrometricFit.py
@@ -260,13 +260,13 @@ class GbdesAstrometricFitConnections(pipeBase.PipelineTaskConnections,
         doc=("Source table with stars used in fit, along with residuals in pixel coordinates and tangent "
              "plane coordinates and chisq values."),
         name='gbdesAstrometricFit_fitStars',
-        storageClass='ArrowTable',
+        storageClass='ArrowNumpyDict',
         dimensions=('instrument', 'skymap', 'tract', 'physical_filter'),
     )
     starCatalog = pipeBase.connectionTypes.Output(
         doc="",
         name='gbdesAstrometricFit_starCatalog',
-        storageClass='ArrowTable',
+        storageClass='ArrowNumpyDict',
         dimensions=('instrument', 'skymap', 'tract', 'physical_filter')
     )
 
@@ -446,6 +446,7 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
             visit = outputRef.dataId['visit']
             butlerQC.put(output.outputWCSs[visit], outputRef)
         butlerQC.put(output.outputCatalog, outputRefs.outputCatalog)
+        butlerQC.put(output.starCatalog, outputRefs.starCatalog)
 
     def run(self, inputCatalogRefs, inputVisitSummaries, instrumentName="", refEpoch=None,
             refObjectLoader=None):
@@ -483,7 +484,7 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
 
         # Get RA, Dec, MJD, etc., for the input visits
         exposureInfo, exposuresHelper, extensionInfo = self._get_exposure_info(inputVisitSummaries,
-                                                                               instrument, refEpoch=refEpoch)
+                                                                               instrument)
 
         # Get information about the extent of the input visits
         fields, fieldCenter, fieldRadius = self._prep_sky(inputVisitSummaries, exposureInfo.medianEpoch)
@@ -496,8 +497,9 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
                                        (self.config.matchRadius * u.arcsec).to(u.degree).value)
 
         # Add the reference catalog to the associator
+        medianEpoch = astropy.time.Time(exposureInfo.medianEpoch, format='decimalyear').mjd
         refObjects, refCovariance = self._load_refcat(associations, refObjectLoader, fieldCenter, fieldRadius,
-                                                      extensionInfo, epoch=refEpoch)
+                                                      extensionInfo, epoch=medianEpoch)
 
         # Add the science catalogs and associate new sources as they are added
         sourceIndices, usedColumns = self._load_catalogs_and_associate(associations, inputCatalogRefs,
@@ -538,9 +540,8 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
         self.log.info("WCS fitting done")
 
         outputWCSs = self._make_outputs(wcsf, inputVisitSummaries, exposureInfo)
-        outputCatalog = pa.Table.from_pydict(wcsf.getOutputCatalog())
-        import ipdb; ipdb.set_trace()
-        starCatalog = parquet.numpy_dict_to_arrow(wcsf.getStarCatalog())
+        outputCatalog = wcsf.getOutputCatalog()
+        starCatalog = wcsf.getStarCatalog()
 
         return pipeBase.Struct(outputWCSs=outputWCSs,
                                fitModel=wcsf,
@@ -700,7 +701,8 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
 
         # Set the reference epoch to be the median of the science visits.
         # The reference catalog will be shifted to this date.
-        medianEpoch = astropy.time.Time(np.median(mjds), format='mjd').decimalyear
+        medianMJD = np.median(mjds)
+        medianEpoch = astropy.time.Time(medianMJD, format='mjd').decimalyear
 
         # Add information for the reference catalog. Most of the values are
         # not used.
@@ -715,7 +717,7 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
         decs.append(0.0)
         airmasses.append(0.0)
         exposureTimes.append(0)
-        mjds.append((refEpoch if (refEpoch is not None) else medianEpoch))
+        mjds.append((refEpoch if (refEpoch is not None) else medianMJD))
         observatories.append(np.array([0, 0, 0]))
         identity = wcsfit.IdentityMap()
         icrs = wcsfit.SphericalICRS()


### PR DESCRIPTION
This also changes the reference catalog loading so that `meas_algorithms` shifts the objects to the median epoch of the fit observations. When proper motion/parallax fitting is turned on, this shift would be done anyway by `gbdes`. It also gives the best results when proper motion/parallax fitting is turned off. 