### PR TITLE
DM-35901: Use the new lsst.utils.tests.ImportTestCase class for import test

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -19,36 +19,19 @@
 # the GNU General Public License along with this program.  If not,
 # see <https://www.lsstcorp.org/LegalNotices/>.
 
-import importlib.resources
-import os.path
 import unittest
 
-from lsst.utils import doImport
+from lsst.utils.tests import ImportTestCase
 
 
-class ImportTestCase(unittest.TestCase):
+class DrpTasksImportTestCase(ImportTestCase):
     """Test that every file can be imported.
 
     drp_tasks does not import all the task code by default and not
     every file will always have a test.
     """
 
-    def test_import(self):
-        self.assertImport("lsst.drp.tasks")
-
-    def assertImport(self, root_pkg):
-        for file in importlib.resources.contents(root_pkg):
-            if not file.endswith(".py"):
-                continue
-            if file.startswith("__"):
-                continue
-            root, ext = os.path.splitext(file)
-            module_name = f"{root_pkg}.{root}"
-            with self.subTest(module=module_name):
-                try:
-                    doImport(module_name)
-                except ImportError as e:
-                    raise AssertionError(f"Error importing module {module_name}: {e}") from e
+    PACKAGES = {"lsst.drp.tasks"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Requires lsst/utils#165