### PR TITLE
DM-40322: Implement hook to define spatial bounds for prerequisites.

### DIFF
--- a/python/lsst/drp/tasks/gbdesAstrometricFit.py
+++ b/python/lsst/drp/tasks/gbdesAstrometricFit.py
@@ -281,6 +281,9 @@ class GbdesAstrometricFitConnections(pipeBase.PipelineTaskConnections,
         dimensions=('instrument', 'skymap', 'tract', 'physical_filter')
     )
 
+    def getSpatialBoundsConnections(self):
+        return ("inputVisitSummaries",)
+
 
 class GbdesAstrometricFitConfig(pipeBase.PipelineTaskConfig,
                                 pipelineConnections=GbdesAstrometricFitConnections):


### PR DESCRIPTION
After this is fully implemented in QG generation (DM-38498) this will allow us to remove the lookupFunction for reference catalog inputs.