### PR TITLE
DM-42086: Clear single-frame streak mask if it exists already

### DIFF
--- a/python/lsst/drp/tasks/assemble_coadd.py
+++ b/python/lsst/drp/tasks/assemble_coadd.py
@@ -1649,6 +1649,12 @@ class CompareWarpAssembleCoaddTask(AssembleCoaddTask):
 
                 if self.config.doFilterMorphological:
                     maskName = self.config.streakMaskName
+                    # clear single frame streak mask if it exists already
+                    if maskName in warpDiffExp.mask.getMaskPlaneDict():
+                        warpDiffExp.mask.clearMaskPlane(warpDiffExp.mask.getMaskPlane(maskName))
+                    else:
+                        self.log.debug(f"Did not (need to) clear {maskName} mask because it didn't exist")
+
                     _ = self.maskStreaks.run(warpDiffExp)
                     streakMask = warpDiffExp.mask
                     spanSetStreak = afwGeom.SpanSet.fromMask(


### PR DESCRIPTION
Before detecting streaks on the difference warps, clear the existing mask if it is already there. The streaks detected on the warp differences should be better. They are straight, cross multiple detectors, and are not competing against the background of static sources