### PR TITLE
DM:41142: Add metadetect as a dependency

### DIFF
--- a/ups/drp_tasks.table
+++ b/ups/drp_tasks.table
@@ -14,6 +14,7 @@ setupRequired(geom)
 setupRequired(pipe_base)
 setupRequired(utils)
 setupRequired(meas_algorithms)
+setupRequired(metadetect)
 setupRequired(pipe_tasks)
 
 # The following is boilerplate for all packages.


### PR DESCRIPTION
This PR is just to test against Jenkins and is not intended to merge in this ticket.