### PR TITLE
DM-42431: Enable coadds from warps with absolute calibration

### DIFF
--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -334,7 +334,7 @@ class AssembleCellCoaddTask(PipelineTask):
 
                 coadd_inputs = coadd_inputs_gc[cellInfo.index]
                 self.input_recorder.addVisitToCoadd(coadd_inputs, warp[bbox], weight)
-                assert len(coadd_inputs.ccds) == 1, "More than one CCD from a warp found within a cell."
+                assert len(coadd_inputs.ccds) <= 1, "More than one CCD from a warp found within a cell."
                 observation_identifier = ObservationIdentifiers.from_data_id(
                     warpRef.dataId,
                     detector=coadd_inputs.ccds[0]["ccd"],

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -336,14 +336,15 @@ class AssembleCellCoaddTask(PipelineTask):
                 # coadd_inputs will have the record of all ccds, even outside
                 # of the current cell's bounding box.
                 self.input_recorder.addVisitToCoadd(coadd_inputs, warp, weight)
-                if False:
-                    #ccd_table = warp.getInfo().getCoaddInputs().ccds.subsetContaining(warp.wcs.pixelToSky(bbox.getCenter()))
+                if True:
                     ccd_table = warp.getInfo().getCoaddInputs().ccds.subsetContaining(cell_centers_sky[cellInfo.index])
                     assert len(ccd_table) > 0, "No CCD from a warp found within a cell."
                     assert len(ccd_table) == 1, "More than one CCD from a warp found within a cell."
-                for ccd_row in warp.getInfo().getCoaddInputs().ccds:
-                    if ccd_row.contains(cell_centers_sky[cellInfo.index]):
-                        break
+                    ccd_row = ccd_table[0]
+                else:
+                    for ccd_row in warp.getInfo().getCoaddInputs().ccds:
+                        if ccd_row.contains(cell_centers_sky[cellInfo.index]):
+                            break
 
                 observation_identifier = ObservationIdentifiers.from_data_id(
                     warpRef.dataId,

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -163,8 +163,10 @@ class AssembleCellCoaddTask(PipelineTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.makeSubtask("input_recorder")
-        self.makeSubtask("interpolate_coadd")
-        self.makeSubtask("scale_zero_point")
+        if self.config.do_interpolate_coadd:
+            self.makeSubtask("interpolate_coadd")
+        if self.config.do_scale_zero_point:
+            self.makeSubtask("scale_zero_point")
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         # Docstring inherited.

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -86,6 +86,11 @@ class AssembleCellCoaddConfig(PipelineTaskConfig, pipelineConnections=AssembleCe
         target=InterpImageTask,
         doc="Task to interpolate (and extrapolate) over pixels with NO_DATA mask on cell coadds",
     )
+    do_scale_zero_point = Field[bool](
+        doc="Scale warps to a common zero point? "
+            "This is not needed they have absolute flux calibration.",
+        default=False,
+    )
     scale_zero_point = ConfigurableField(
         target=ScaleZeroPointTask,
         doc="Task to scale warps to a common zero point",
@@ -296,7 +301,8 @@ class AssembleCellCoaddTask(PipelineTask):
             # Each Warp that goes into a coadd will typically have an
             # independent photometric zero-point. Therefore, we must scale each
             # Warp to set it to a common photometric zeropoint.
-            self.scale_zero_point.run(exposure=warp, dataRef=warpRef)
+            if self.config.do_scale_zero_point:
+                self.scale_zero_point.run(exposure=warp, dataRef=warpRef)
 
             # Coadd the warp onto the cells it completely overlaps.
             edge = afwImage.Mask.getPlaneBitMask("EDGE")

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -392,7 +392,7 @@ class AssembleCellCoaddTask(PipelineTask):
 
             singleCellCoadd = SingleCellCoadd(
                 outer=image_planes,
-                psf=cell_coadd_psf.computeKernelImage(cell_coadd_psf.getAveragePosition()),
+                psf=cell_coadd_psf.computeKernelImage(cellInfo.inner_bbox.getCenter()),
                 inner_bbox=cellInfo.inner_bbox,
                 inputs=frozenset(observation_identifiers_gc[cellInfo.index]),
                 common=self.common,

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -87,8 +87,7 @@ class AssembleCellCoaddConfig(PipelineTaskConfig, pipelineConnections=AssembleCe
         doc="Task to interpolate (and extrapolate) over pixels with NO_DATA mask on cell coadds",
     )
     do_scale_zero_point = Field[bool](
-        doc="Scale warps to a common zero point? "
-            "This is not needed they have absolute flux calibration.",
+        doc="Scale warps to a common zero point? This is not needed they have absolute flux calibration.",
         default=False,
     )
     scale_zero_point = ConfigurableField(

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -461,11 +461,6 @@ class ConvertMultipleCellCoaddToExposureTask(PipelineTask):
     ConfigClass = ConvertMultipleCellCoaddToExposureConfig
     _DefaultName = "convertMultipleCellCoaddToExposure"
 
-    def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        inputData = butlerQC.get(inputRefs)
-        returnStruct = self.run(**inputData)
-        butlerQC.put(returnStruct, outputRefs)
-
     def run(self, cellCoaddExposure):
         return Struct(
             stitchedCoaddExposure=cellCoaddExposure.stitch().asExposure(),

--- a/python/lsst/drp/tasks/assemble_cell_coadd.py
+++ b/python/lsst/drp/tasks/assemble_cell_coadd.py
@@ -437,13 +437,11 @@ class ConvertMulipleCellCoaddToExposureConnections(
 
 
 class ConvertMultipleCellCoaddToExposureConfig(
-    PipelineTaskConfig, pipelineConnections=ConvertMulipleCellCoaddToExposureConnections
+    PipelineTaskConfig, pipelineConnections=ConvertMultipleCellCoaddToExposureConnections
 ):
     """A trivial PipelineTaskConfig class for
     ConvertMultipleCellCoaddToExposureTask.
     """
-
-    pass
 
 
 class ConvertMultipleCellCoaddToExposureTask(PipelineTask):


### PR DESCRIPTION
This PR allows to skip scaling to a common zero point by default, since the warps from `MakeDirectWarp` task produce warps with pixel units in nJy.