### PR TITLE
DM-47181: Fix Catalog format for LSSTComCam and raise NoWorkFound issue for not enough data in gbdes. 

### DIFF
--- a/python/lsst/drp/tasks/gbdesAstrometricFit.py
+++ b/python/lsst/drp/tasks/gbdesAstrometricFit.py
@@ -1226,11 +1226,18 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
 
         # Get refcat version from refcat metadata
         refCatMetadata = refObjectLoader.refCats[0].get().getMetadata()
-        refCatVersion = refCatMetadata["REFCAT_FORMAT_VERSION"]
-        if refCatVersion == 2:
+
+        # DM-47181: Added this to work for LSSTComCam with
+        # the_monster_20240904 catalog that has not this key.
+        if "REFCAT_FORMAT_VERSION" not in refCatMetadata:
+            refCatVersion = 2
             raDecCov = (refCat["coord_ra_coord_dec_Cov"]).to(u.degree**2).to_value().tolist()
         else:
-            raDecCov = np.zeros(len(ra))
+            refCatVersion = refCatMetadata["REFCAT_FORMAT_VERSION"]
+            if refCatVersion == 2:
+                raDecCov = (refCat["coord_ra_coord_dec_Cov"]).to(u.degree**2).to_value().tolist()
+            else:
+                raDecCov = np.zeros(len(ra))
 
         refObjects = {"ra": ra, "dec": dec, "raCov": raCov, "decCov": decCov, "raDecCov": raDecCov}
         refCovariance = []

--- a/python/lsst/drp/tasks/gbdesAstrometricFit.py
+++ b/python/lsst/drp/tasks/gbdesAstrometricFit.py
@@ -1468,7 +1468,7 @@ class GbdesAstrometricFitTask(pipeBase.PipelineTask):
                     unconstrainedDetectors.append(str(detector))
 
             if unconstrainedDetectors:
-                raise RuntimeError(
+                raise pipeBase.NoWorkFound(
                     "The model is not constrained. The following detectors do not have enough "
                     f"sources ({nCoeffDetectorModel} required): ",
                     ", ".join(unconstrainedDetectors),


### PR DESCRIPTION
There is no `REFCAT_FORMAT_VERSION` for `the_monster_20240904` catalog. The code here is a way to move forward without this key. 