### PR TITLE
DM-44791: Remove the deprecated doUsePsfMatchedPolygons field

### DIFF
--- a/python/lsst/drp/tasks/assemble_coadd.py
+++ b/python/lsst/drp/tasks/assemble_coadd.py
@@ -223,17 +223,6 @@ class AssembleCoaddConfig(
         dtype=bool,
         default=False,
     )
-    # TODO: Remove this field in DM-44791 after v28 release is cut.
-    doUsePsfMatchedPolygons = pexConfig.Field(
-        doc="Use ValidPolygons from shrunk Psf-Matched Calexps? Should be set "
-        "to True by CompareWarp only.",
-        dtype=bool,
-        default=False,
-        deprecated=(
-            "This configuration is handled internally and deprecated "
-            "without replacement. This will be removed after v28."
-        ),
-    )
     maskPropagationThresholds = pexConfig.DictField(
         keytype=str,
         itemtype=float,


### PR DESCRIPTION
Remove the deprecated field before v29 release is cut.