### PR TITLE
DM-49263-v29: backport deprecating and disabling photometric calibration uncertainty propagation

### DIFF
--- a/python/lsst/drp/tasks/make_direct_warp.py
+++ b/python/lsst/drp/tasks/make_direct_warp.py
@@ -318,7 +318,7 @@ class MakeDirectWarpConfig(
     includeCalibVar = Field[bool](
         doc="Add photometric calibration variance to warp variance plane?",
         default=False,
-        deprecated="Deprecated and disabled.  Will be removed after v30.",
+        deprecated="Deprecated and disabled.  Will be removed after v29.",
     )
     border = Field[int](
         doc="Pad the patch boundary of the warp by these many pixels, so as to allow for PSF-matching later",


### PR DESCRIPTION
This also includes one commit that is not (yet) on main that just updates the release in which the deprecated interfaces will be removed after from v30 to v29, reflecting the fact that the deprecation is happening earlier. This commit will be added to main after the backport is complete.
