### PR TITLE
DM-49263-v29: Shift removal to post-v29 to reflect deprecation in v29 (forward-port)

### DIFF
--- a/python/lsst/drp/tasks/make_direct_warp.py
+++ b/python/lsst/drp/tasks/make_direct_warp.py
@@ -318,7 +318,7 @@ class MakeDirectWarpConfig(
     includeCalibVar = Field[bool](
         doc="Add photometric calibration variance to warp variance plane?",
         default=False,
-        deprecated="Deprecated and disabled.  Will be removed after v30.",
+        deprecated="Deprecated and disabled.  Will be removed after v29.",
     )
     border = Field[int](
         doc="Pad the patch boundary of the warp by these many pixels, so as to allow for PSF-matching later",


### PR DESCRIPTION
With the deprecations from DM-49263 now appearing in v29 due a backport, we also need to adjust the deprecation clock on main.