### PR TITLE
DM-47521: Refer to makeDirectWarp from drp_tasks

### DIFF
--- a/doc/lsst.drp.tasks/tasks/lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask.rst
+++ b/doc/lsst.drp.tasks/tasks/lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask
+.. lsst-task-topic:: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask
 
 ##################
 MakeDirectWarpTask
@@ -9,23 +9,23 @@ Warp single visit images (calexps or PVIs) onto a common projection by performin
 - Group the single-visit images by visit/run
 - For each visit, generate a Warp by calling method @ref run.
 
-.. _lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask-api:
+.. _lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask
+.. lsst-task-api-summary:: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask
 
-.. _lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask-subtasks:
+.. _lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask
+.. lsst-task-config-subtasks:: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask
 
-.. _lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask-configs:
+.. _lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.pipe.tasks.make_direct_warp.MakeDirectWarpTask
+.. lsst-task-config-fields:: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask

--- a/doc/lsst.drp.tasks/tasks/lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask.rst
+++ b/doc/lsst.drp.tasks/tasks/lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
+.. lsst-task-topic:: lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
 
 ######################
 MakePsfMatchedWarpTask
@@ -13,26 +13,26 @@ The subtask `~lsst.ip.diffim.modelPsfMatch.ModelPsfMatchTask` is responsible for
 The optimal configuration depends on aspects of dataset: the pixel scale, average PSF FWHM and dimensions of the PSF kernel.
 These configs include the requested model PSF, the matching kernel size, padding of the science PSF thumbnail and spatial sampling frequency of the PSF.
 
-.. _lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-api:
+.. _lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
+.. lsst-task-api-summary:: lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
 
-.. _lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-subtasks:
+.. _lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
+.. lsst-task-config-subtasks:: lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
 
-.. _lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-configs:
+.. _lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.pipe.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
+.. lsst-task-config-fields:: lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
 
 In Depth
 ========


### PR DESCRIPTION
When the docs moved from `pipe_tasks` to `drp_tasks`, these should have been renamed but weren't. Now that they are removed in `pipe_tasks`, not redirecting this breaks the documentation build.