### PR TITLE
DM-49994-v29: make coaddition work on visit_image

### DIFF
--- a/python/lsst/drp/tasks/make_direct_warp.py
+++ b/python/lsst/drp/tasks/make_direct_warp.py
@@ -825,10 +825,6 @@ class MakeDirectWarpTask(PipelineTask):
                     )
                     return False
 
-            elif visit_summary is not None:
-                # We can only get here by calling `run`, not `runQuantum`.
-                raise RuntimeError("useVisitSummaryPsf=True, but visit_summary is provided. ")
-
         if self.config.doApplyNewBackground:
             detector_inputs.apply_background()
         elif detector_inputs.background_apply:

--- a/python/lsst/drp/tasks/make_direct_warp.py
+++ b/python/lsst/drp/tasks/make_direct_warp.py
@@ -216,7 +216,9 @@ class MakeDirectWarpConnections(
             del self.background_revert_list
         if not config.doApplyNewBackground:
             del self.background_apply_list
-        if not config.doApplyFlatBackgroundRatio:
+        if not config.doApplyFlatBackgroundRatio or (
+            not config.doRevertOldBackground and not config.doApplyNewBackground
+        ):
             del self.background_to_photometric_ratio_list
 
         if not config.doWarpMaskedFraction:


### PR DESCRIPTION
This is the real DM-49994 v29 backport; the one that already landed was an embarrassing mistake, in which I apparently put the commits from DM-50980 on a DM-49994-v29 backport branch, tested them, and merged them to v29.1.x just before the 29.1.0 release.