### PR TITLE
Revert DM-51882

### DIFF
--- a/python/lsst/drp/tasks/single_frame_detect_and_measure.py
+++ b/python/lsst/drp/tasks/single_frame_detect_and_measure.py
@@ -185,7 +185,7 @@ class SingleFrameDetectAndMeasureTask(pipeBase.PipelineTask):
             type="U",
             doc="Detector this source appeared on.",
         )
-        afwTable.CoordKey.addErrorFields(schema)
+
         self.schema = schema
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):


### PR DESCRIPTION
Reverts DM-51882: "Ensure coordinate error fields are present in single frame schema"
This reverts commit 3d56e0b51e3810aa26ac738c479c508462ebf506.