### PR TITLE
DM-54226: Get grid with shear bands

### DIFF
--- a/python/lsst/drp/tasks/metadetection_shear.py
+++ b/python/lsst/drp/tasks/metadetection_shear.py
@@ -704,7 +704,7 @@ class MetadetectionShearTask(PipelineTask):
         self.rng = np.random.RandomState(seed)
         idstart = 0
 
-        grid = patch_coadds[self.config.photometry_bands[0]].grid
+        grid = patch_coadds[self.config.metadetect.shear_bands[0]].grid
         nx_cells, ny_cells = grid.shape
         single_cell_tables: list[pa.Table] = []
         for nx, ny in product(range(nx_cells), range(ny_cells)):


### PR DESCRIPTION
To get the grid of cells, it does not matter which particular band we choose. It is robust to rely on shear_bands, that are guaranteed to exist instead of photometry_bands, that may or may not exist.